### PR TITLE
feat(kubernetes): bootstrapped Kubernetes MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ jbang -q jfx@quarkiverse/quarkus-mcp-servers
 
 See more in the [jfx readme](jfx/README.md).
 
+
+### [kubernetes](kubernetes)
+
+The `kubernetes` server can be used to interact with a Kubernetes cluster.
+
+```shell
+jbang -q kubernetes@quarkiverse/quarkus-mcp-servers
+```
+
 ## Ideas for other servers
 
 If you have ideas for other servers, feel free to contribute them to this project.

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -32,8 +32,12 @@
       "script-ref": "https://github.com/quarkiverse/quarkus-mcp-servers/releases/download/early-access/mcp-server-jfx.jar",
       "java": "17+",
       "dependencies": ["org.openjfx:javafx-controls:21", "org.openjfx:javafx-graphics:21", "org.openjfx:javafx-swing:21"]
+    },
+    "kubernetes": {
+      "script-ref": "kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java",
+      "java": "17+"
     }
-    
+
   },
   "templates": {}
 }

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-kubernetes</artifactId>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp.servers</groupId>
+        <artifactId>mcp-servers-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/kubernetes/src/main/docker/Dockerfile.jvm
+++ b/kubernetes/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,97 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/mcp-server-jdbc-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc-jvm
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+
+ENV LANGUAGE='en_US:en'
+
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=185 target/quarkus-app/*.jar /deployments/
+COPY --chown=185 target/quarkus-app/app/ /deployments/app/
+COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]
+

--- a/kubernetes/src/main/docker/Dockerfile.legacy-jar
+++ b/kubernetes/src/main/docker/Dockerfile.legacy-jar
@@ -1,0 +1,93 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dquarkus.package.jar.type=legacy-jar
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/mcp-server-jdbc-legacy-jar .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc-legacy-jar
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
+# Additionally you will have to set -e JAVA_DEBUG=true and -e JAVA_DEBUG_PORT=*:5005
+# when running the container
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc-legacy-jar
+#
+# This image uses the `run-java.sh` script to run the application.
+# This scripts computes the command line to execute your Java application, and
+# includes memory/GC tuning.
+# You can configure the behavior using the following environment properties:
+# - JAVA_OPTS: JVM options passed to the `java` command (example: "-verbose:class")
+# - JAVA_OPTS_APPEND: User specified Java options to be appended to generated options
+#   in JAVA_OPTS (example: "-Dsome.property=foo")
+# - JAVA_MAX_MEM_RATIO: Is used when no `-Xmx` option is given in JAVA_OPTS. This is
+#   used to calculate a default maximal heap memory based on a containers restriction.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio
+#   of the container available memory as set here. The default is `50` which means 50%
+#   of the available memory is used as an upper boundary. You can skip this mechanism by
+#   setting this value to `0` in which case no `-Xmx` option is added.
+# - JAVA_INITIAL_MEM_RATIO: Is used when no `-Xms` option is given in JAVA_OPTS. This
+#   is used to calculate a default initial heap memory based on the maximum heap memory.
+#   If used in a container without any memory constraints for the container then this
+#   option has no effect. If there is a memory constraint then `-Xms` is set to a ratio
+#   of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx`
+#   is used as the initial heap size. You can skip this mechanism by setting this value
+#   to `0` in which case no `-Xms` option is added (example: "25")
+# - JAVA_MAX_INITIAL_MEM: Is used when no `-Xms` option is given in JAVA_OPTS.
+#   This is used to calculate the maximum value of the initial heap memory. If used in
+#   a container without any memory constraints for the container then this option has
+#   no effect. If there is a memory constraint then `-Xms` is limited to the value set
+#   here. The default is 4096MB which means the calculated value of `-Xms` never will
+#   be greater than 4096MB. The value of this variable is expressed in MB (example: "4096")
+# - JAVA_DIAGNOSTICS: Set this to get some diagnostics information to standard output
+#   when things are happening. This option, if set to true, will set
+#  `-XX:+UnlockDiagnosticVMOptions`. Disabled by default (example: "true").
+# - JAVA_DEBUG: If set remote debugging will be switched on. Disabled by default (example:
+#    true").
+# - JAVA_DEBUG_PORT: Port used for remote debugging. Defaults to 5005 (example: "8787").
+# - CONTAINER_CORE_LIMIT: A calculated core limit as described in
+#   https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt. (example: "2")
+# - CONTAINER_MAX_MEMORY: Memory limit given to the container (example: "1024").
+# - GC_MIN_HEAP_FREE_RATIO: Minimum percentage of heap free after GC to avoid expansion.
+#   (example: "20")
+# - GC_MAX_HEAP_FREE_RATIO: Maximum percentage of heap free after GC to avoid shrinking.
+#   (example: "40")
+# - GC_TIME_RATIO: Specifies the ratio of the time spent outside the garbage collection.
+#   (example: "4")
+# - GC_ADAPTIVE_SIZE_POLICY_WEIGHT: The weighting given to the current GC time versus
+#   previous GC times. (example: "90")
+# - GC_METASPACE_SIZE: The initial metaspace size. (example: "20")
+# - GC_MAX_METASPACE_SIZE: The maximum metaspace size. (example: "100")
+# - GC_CONTAINER_OPTIONS: Specify Java GC to use. The value of this variable should
+#   contain the necessary JRE command-line options to specify the required GC, which
+#   will override the default of `-XX:+UseParallelGC` (example: -XX:+UseG1GC).
+# - HTTPS_PROXY: The location of the https proxy. (example: "myuser@127.0.0.1:8080")
+# - HTTP_PROXY: The location of the http proxy. (example: "myuser@127.0.0.1:8080")
+# - NO_PROXY: A comma separated lists of hosts, IP addresses or domains that can be
+#   accessed directly. (example: "foo.example.com,bar.example.com")
+#
+###
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.20
+
+ENV LANGUAGE='en_US:en'
+
+
+COPY target/lib/* /deployments/lib/
+COPY target/*-runner.jar /deployments/quarkus-run.jar
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/kubernetes/src/main/docker/Dockerfile.native
+++ b/kubernetes/src/main/docker/Dockerfile.native
@@ -1,0 +1,27 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/mcp-server-jdbc .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc
+#
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/kubernetes/src/main/docker/Dockerfile.native-micro
+++ b/kubernetes/src/main/docker/Dockerfile.native-micro
@@ -1,0 +1,30 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in native (no JVM) mode.
+# It uses a micro base image, tuned for Quarkus native executables.
+# It reduces the size of the resulting container image.
+# Check https://quarkus.io/guides/quarkus-runtime-base-image for further information about this image.
+#
+# Before building the container image run:
+#
+# ./mvnw package -Dnative
+#
+# Then, build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/mcp-server-jdbc .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8080:8080 quarkus/mcp-server-jdbc
+#
+###
+FROM quay.io/quarkus/quarkus-micro-image:2.0
+WORKDIR /work/
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --chown=1001:root target/*-runner /work/application
+
+EXPOSE 8080
+USER 1001
+
+ENTRYPOINT ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java
+++ b/kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java
@@ -1,0 +1,90 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+package io.quarkus.mcp.servers.kubernetes;
+//JAVA 17+
+//DEPS io.quarkus:quarkus-bom:3.17.6@pom
+//DEPS io.quarkus:quarkus-kubernetes-client
+//DEPS io.quarkiverse.mcp:quarkus-mcp-server-stdio:1.0.0.Alpha5
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.Startup;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class MCPServerKubernetes {
+
+  @Inject
+  KubernetesClient kubernetesClient;
+
+  @Startup
+  void init() {
+    Log.info("Starting Kubernetes server with master URL: " + kubernetesClient.getConfiguration().getMasterUrl());
+  }
+
+  @Tool(description = "Get the current Kubernetes configuration")
+  public String configuration_Get() {
+    return kubernetesClient.getKubernetesSerialization().asJson(kubernetesClient.getConfiguration());
+  }
+
+  @Tool(description = "List all the Kubernetes namespaces in the current cluster")
+  public String namespaces_list() {
+    return kubernetesClient.getKubernetesSerialization().asJson(
+      kubernetesClient.namespaces().list().getItems()
+    );
+  }
+
+  @Tool(description = "List all the Kubernetes pods in the current cluster")
+  public String pods_list() {
+    return kubernetesClient.getKubernetesSerialization().asJson(
+      kubernetesClient.pods().list().getItems()
+    );
+  }
+
+  @Tool(description = "List all the Kubernetes pods in the specified namespace in the current cluster")
+  public String pods_list_in_namespace(@ToolArg(description = "Namespace to list pods from") String namespace) {
+    return kubernetesClient.getKubernetesSerialization().asJson(
+      kubernetesClient.pods().inNamespace(namespace).list().getItems()
+    );
+  }
+
+  @Tool(description = "Run a Pod in the current namespace with the provided container image and optional name")
+  public String pods_run(
+    @ToolArg(description = "Namespace to run the Pod in", required = false) String namespace,
+    @ToolArg(description = "Container Image to run in the Pod") String image,
+    @ToolArg(description = "Name of the Pod", required = false) String name
+  ) {
+    return kubernetesClient.getKubernetesSerialization().asJson(
+      kubernetesClient.run()
+        .inNamespace(namespace == null ? kubernetesClient.getNamespace() : namespace)
+        .withName(name == null ? "mcp-kubernetes-pod-" + System.currentTimeMillis() : name)
+        .withImage(image)
+        .withNewRunConfig()
+        .addToLabels("app", "mcp-kubernetes")
+        .addToLabels("k8s.io/created-by", "mcp-kubernetes")
+        .done()
+    );
+  }
+
+  @Tool(description = "Delete a Pod in the current namespace with the provided name")
+  public ToolResponse pods_delete(
+    @ToolArg(description = "Namespace to delete the Pod from", required = false) String namespace,
+    @ToolArg(description = "Name of the Pod to delete") String name
+  ) {
+    try {
+      kubernetesClient.pods()
+        .inNamespace(namespace == null ? kubernetesClient.getNamespace() : namespace)
+        .withName(name)
+        .withTimeout(10, TimeUnit.SECONDS)
+        .delete();
+    } catch (Exception e) {
+      return ToolResponse.error("Failed to delete Pod: " + e.getMessage());
+    }
+    return ToolResponse.success("Pod deleted successfully");
+  }
+}

--- a/kubernetes/src/main/resources/application.properties
+++ b/kubernetes/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+
+# Logging
+#quarkus.log.level=DEBUG
+#quarkus.log.console.stderr=true

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>jdbc</module>
         <module>filesystem</module>
         <module>jfx</module>
+        <module>kubernetes</module>
 
     </modules>
 
@@ -29,15 +30,15 @@
         <surefire-plugin.version>3.5.0</surefire-plugin.version>
 
 <!--
-         <mcp.server.version>999-SNAPSHOT</mcp.server.version> 
-    -->     
+         <mcp.server.version>999-SNAPSHOT</mcp.server.version>
+    -->
         <mcp.server.version>1.0.0.Alpha6</mcp.server.version>
-       
+
     </properties>
 
     <dependencyManagement>
         <dependencies>
-           
+
         </dependencies>
     </dependencyManagement>
 
@@ -106,4 +107,4 @@
         </profile>
 </profiles>
 
-</project> 
+</project>


### PR DESCRIPTION
## Description

Initial MCP server prototype for Kubernetes (and OpenShift).

Tested with Claude Desktop (3.5 Sonnet) on Windows and Goose (gemini-1.5-flash -Google AI Studio-) on Linux.

Command:

```shell
jbang.cmd --fresh https://github.com/marcnuri-forks/quarkus-mcp-servers/blob/feat/kubernetes/kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java
```

It's working surprisingly well.

As an example, I deployed nginx:latest in OpenShift and it immediately evaluated the reason for the CrashLoopBackOff:

```
View result from pods_list from kubernetes (local) >

I notice that the pod is in a CrashLoopBackOff state. This is happening because the pod is configured to run as a non-root user (due to security constraints), but the default Nginx container tries to run as root.
```

I'll add a video demo later on (will attach a draft to this PR for comments).

Regarding the jbang catalog file, I'm not sure if my settings are correct.

/cc @maxandersen 

Relates to https://github.com/fabric8io/kubernetes-client/issues/6843
