### PR TITLE
feat(kubernetes): improved native compilation and native binary image size

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -31,10 +31,76 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
         </dependency>
+        <!-- Add only those dependencies that are actually needed to minimize the native image size -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-admissionregistration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-autoscaling</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-batch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-certificates</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-coordination</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-node</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java
+++ b/kubernetes/src/main/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetes.java
@@ -8,7 +8,6 @@ package io.quarkus.mcp.servers.kubernetes;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,7 +29,7 @@ public class MCPServerKubernetes {
   }
 
   @Tool(description = "Get the current Kubernetes configuration")
-  public String configuration_Get() {
+  public String configuration_get() {
     try {
       return kubernetesClient.getKubernetesSerialization().asJson(kubernetesClient.getConfiguration());
     } catch (Exception e) {
@@ -62,7 +61,7 @@ public class MCPServerKubernetes {
 
   @Tool(description = "List all the Kubernetes pods in the specified namespace in the current cluster")
   public String pods_list_in_namespace(@ToolArg(description = "Namespace to list pods from") String namespace) {
-    try { 
+    try {
       return kubernetesClient.getKubernetesSerialization().asJson(
         kubernetesClient.pods().inNamespace(namespace).list().getItems()
       );
@@ -78,16 +77,16 @@ public class MCPServerKubernetes {
     @ToolArg(description = "Name of the Pod", required = false) String name
   ) {
     try {
-    return kubernetesClient.getKubernetesSerialization().asJson(
-      kubernetesClient.run()
-        .inNamespace(namespace == null ? kubernetesClient.getNamespace() : namespace)
-        .withName(name == null ? "mcp-kubernetes-pod-" + System.currentTimeMillis() : name)
-        .withImage(image)
-        .withNewRunConfig()
-        .addToLabels("app", "mcp-kubernetes")
-        .addToLabels("k8s.io/created-by", "mcp-kubernetes")
-        .done()
-    );
+      return kubernetesClient.getKubernetesSerialization().asJson(
+        kubernetesClient.run()
+          .inNamespace(namespace == null ? kubernetesClient.getNamespace() : namespace)
+          .withName(name == null ? "mcp-kubernetes-pod-" + System.currentTimeMillis() : name)
+          .withImage(image)
+          .withNewRunConfig()
+          .addToLabels("app", "mcp-kubernetes")
+          .addToLabels("k8s.io/created-by", "mcp-kubernetes")
+          .done()
+      );
     } catch (Exception e) {
       throw new ToolCallException("Failed to run pod: " + e.getMessage(), e);
     }

--- a/kubernetes/src/main/resources/application.properties
+++ b/kubernetes/src/main/resources/application.properties
@@ -4,3 +4,7 @@ quarkus.package.jar.add-runner-suffix=false
 # Logging
 #quarkus.log.level=DEBUG
 #quarkus.log.console.stderr=true
+
+%test.quarkus.kubernetes-client.devservices.enabled=true
+%test.quarkus.kubernetes-client.devservices.override-kubeconfig=true
+%test.quarkus.kubernetes-client.devservices.flavor=api-only

--- a/kubernetes/src/test/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetesTest.java
+++ b/kubernetes/src/test/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetesTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.mcp.servers.kubernetes;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Basic unit test suite for the {@link MCPServerKubernetes} class.
+ * <p>
+ * TODO: Create a different test suite (integration) once quarkus-mcp-server-test-utils is more complete
+ * https://github.com/quarkiverse/quarkus-mcp-server/tree/main/test-utils
+ */
+@QuarkusTest
+@DisabledOnOs(OS.WINDOWS)
+class MCPServerKubernetesTest {
+
+  @Inject
+  KubernetesClient kubernetesClient;
+  @Inject
+  MCPServerKubernetes server;
+
+  @Test
+  void configuration_get_returnsTestKubernetesMasterUrl() {
+    assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(server.configuration_get(), GenericKubernetesResource.class))
+      .extracting(gkr -> gkr.get("masterUrl")).asString()
+      .startsWith("https://localhost:");
+  }
+
+  @Test
+  void namespaces_list() {
+    kubernetesClient.namespaces()
+      .resource(new NamespaceBuilder().withNewMetadata().withName("a-namespace-to-list").endMetadata().build())
+      .serverSideApply();
+    assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(server.namespaces_list(), List.class))
+      .extracting("metadata.name")
+      .contains("a-namespace-to-list");
+  }
+
+  @Test
+  void pods_list() {
+    kubernetesClient
+      .resource(new ServiceAccountBuilder().withNewMetadata().withName("default").endMetadata().build())
+      .createOr(NonDeletingOperation::update);
+    kubernetesClient.run()
+      .withName("a-pod-to-list")
+      .withImage("busybox")
+      .done();
+    assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(server.pods_list(), List.class))
+      .extracting("metadata.name")
+      .contains("a-pod-to-list");
+  }
+
+  @Test
+  void pods_list_in_namespace() {
+    kubernetesClient
+      .resource(new ServiceAccountBuilder().withNewMetadata().withName("default").endMetadata().build())
+      .createOr(NonDeletingOperation::update);
+    kubernetesClient.run()
+      .withName("a-pod-to-list-in-namespace")
+      .withImage("busybox")
+      .done();
+    assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(server.pods_list_in_namespace("default"), List.class))
+      .extracting("metadata.name")
+      .contains("a-pod-to-list-in-namespace");
+  }
+
+  @Test
+  void pods_run() {
+    server.pods_run("default", "busybox", "a-pod-to-run");
+    assertThat(kubernetesClient.pods().inNamespace("default").withName("a-pod-to-run")
+      .waitUntilCondition(Objects::nonNull, 10, TimeUnit.SECONDS))
+      .isNotNull()
+      .hasFieldOrPropertyWithValue("metadata.name", "a-pod-to-run");
+  }
+
+  @Test
+  void pods_delete() {
+    kubernetesClient
+      .resource(new ServiceAccountBuilder().withNewMetadata().withName("default").endMetadata().build())
+      .createOr(NonDeletingOperation::update);
+    kubernetesClient.run()
+      .withName("a-pod-to-delete")
+      .withImage("busybox")
+      .done();
+    assertThat(server.pods_delete(null, "a-pod-to-delete"))
+      .isEqualTo("Pod deleted successfully");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.17.6</quarkus.platform.version>
         <skipITs>true</skipITs>
+        <assertj.version>3.27.3</assertj.version>
         <surefire-plugin.version>3.5.0</surefire-plugin.version>
 
 <!--
@@ -38,7 +39,12 @@
 
     <dependencyManagement>
         <dependencies>
-
+          <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+          </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Added tests to ensure client works with restricted dependency-set

Further integration tests will be added once quarkus-mcp-server-test-utils stabilized.

Tested with Goose (gemini-1.5-flash -Google AI Studio-) on Linux.

Command:
```
/home/user/00-MN/projects/forks/quarkus-mcp-servers/kubernetes/target/mcp-server-kubernetes-linux-x86_64
```

Results are incredible, proves to be a good replacement for kubectl altogether.
<details>
<summary>Check following conversation</summary>

```
starting session | provider: google model: gemini-1.5-flash
    logging to /home/user/.config/goose/sessions/lZXUG8Xy.jsonl


Goose is running! Enter your instructions, or try asking what goose can do.


( O)> list namespaces

─── namespaces_list | kubernetes-native ──────────────────────────



The namespaces are: default, devbcn-2024, headlamp, ingress-nginx, kube-node-lease, kube-public, kube-system, kubernetes-dashboard, and yakd-dashb
oard.

( O)> create a pod with nginx:latest image
What namespace should I create the pod in?  And do you want to give it a specific name?

( O)> default namespace, give it a random name

─── pods_run | kubernetes-native ──────────────────────────
image: nginx:latest
namespace: default



A pod named `mcp-kubernetes-pod-1738325869029` has been created in the `default` namespace using the `nginx:latest` image.  Its status is currentl
y `Pending`.

( O)> create 2 more

─── pods_run | kubernetes-native ──────────────────────────
image: nginx:latest
namespace: default


─── pods_run | kubernetes-native ──────────────────────────
image: nginx:latest
namespace: default



Two more pods,  `mcp-kubernetes-pod-1738325875234` and `mcp-kubernetes-pod-1738325875243`, have been created in the `default` namespace using the 
`nginx:latest` image.  Both are currently in a `Pending` state.

( O)> list pods

─── pods_list | kubernetes-native ──────────────────────────



There are four pods listed.  One is named `nginx-d7f5d89c9-q6tfs` and is running. Another is named `spring-boot-645f879bb6-5j8z4` and is running. 
 A third is named `test-project-769fcf4498-bdlhg` and is running. The remaining three pods (`mcp-kubernetes-pod-1738325685872`, `mcp-kubernetes-po
d-1738325869029`, `mcp-kubernetes-pod-1738325875234`, `mcp-kubernetes-pod-1738325875243`) are all in the `Pending` state.

( O)> delete all pods with name starting by mcp-kubernetes

─── pods_delete | kubernetes-native ──────────────────────────
name: mcp-kubernetes-pod-1738325685872
namespace: default


─── pods_delete | kubernetes-native ──────────────────────────
name: mcp-kubernetes-pod-1738325869029
namespace: default


─── pods_delete | kubernetes-native ──────────────────────────
name: mcp-kubernetes-pod-1738325875234
namespace: default


─── pods_delete | kubernetes-native ──────────────────────────
name: mcp-kubernetes-pod-1738325875243
namespace: default



The pods `mcp-kubernetes-pod-1738325685872`, `mcp-kubernetes-pod-1738325869029`, `mcp-kubernetes-pod-1738325875234`, and `mcp-kubernetes-pod-17383
25875243` have been deleted.

```
</details>