### PR TITLE
test(kubernetes): bootstrapped integration tests

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--suppress MavenModelInspection -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.mcp.servers</groupId>
@@ -11,7 +12,7 @@
     </parent>
 
     <properties>
-
+        <skipITs>false</skipITs>
     </properties>
 
     <dependencyManagement>
@@ -103,6 +104,16 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mcp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -153,7 +164,9 @@
                 </executions>
                 <configuration>
                     <systemPropertyVariables>
-                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <quarkus.native.enabled>${quarkus.native.enabled}</quarkus.native.enabled>
+                        <java.jar.path>${project.build.directory}/${project.build.finalName}.jar</java.jar.path>
+                        <native.image.path>${project.build.directory}/${quarkus.package.output-name}</native.image.path>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                     </systemPropertyVariables>

--- a/kubernetes/src/test/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetesIT.java
+++ b/kubernetes/src/test/java/io/quarkus/mcp/servers/kubernetes/MCPServerKubernetesIT.java
@@ -1,0 +1,125 @@
+package io.quarkus.mcp.servers.kubernetes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.mcp.client.DefaultMcpClient;
+import dev.langchain4j.mcp.client.McpClient;
+import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MCPServerKubernetesIT {
+
+  private static KubernetesMockServer mockServer;
+  private static KubernetesClient kubernetesClient;
+  private static McpClient client;
+
+  @BeforeAll
+  static void initMcpClient() throws Exception {
+    mockServer = new KubernetesMockServer(new Context(new ObjectMapper()),
+      new MockWebServer(), new HashMap<>(), new KubernetesCrudDispatcher(), true);
+    mockServer.init();
+    kubernetesClient = mockServer.createClient();
+    final var kubeConfigArgs = List.of(
+      "-Dquarkus.kubernetes-client.api-server-url=" + kubernetesClient.getConfiguration().getMasterUrl(),
+      "-Dquarkus.kubernetes-client.trust-certs=true",
+      "-Dquarkus.kubernetes-client.namespace=test"
+    );
+    final List<String> command = new ArrayList<>();
+    if (Objects.equals(System.getProperty("quarkus.native.enabled"), "true")) {
+      command.add(System.getProperty("native.image.path"));
+      command.addAll(kubeConfigArgs);
+    } else {
+      command.add(ProcessHandle.current().info().command().orElseThrow());
+      command.addAll(kubeConfigArgs);
+      command.add("-jar");
+      command.add(System.getProperty("java.jar.path"));
+    }
+    final var transport = new StdioMcpTransport.Builder().command(command).logEvents(true).build();
+    client = new DefaultMcpClient.Builder()
+      .clientName("test-mcp-client-kubernetes")
+      .toolExecutionTimeout(Duration.ofSeconds(10))
+      .transport(transport)
+      .build();
+    // TODO: Remove once LangChain4J is fixed (1.0.0-alpha2)
+    // https://github.com/langchain4j/langchain4j/pull/2360
+    // https://github.com/langchain4j/langchain4j/issues/2341#issuecomment-2564081377
+    final var execute = StdioMcpTransport.class.getDeclaredMethod("execute", String.class, Long.class);
+    execute.setAccessible(true);
+    execute.invoke(transport, "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}", 1000L);
+  }
+
+  @AfterAll
+  static void closeMcpClient() {
+    kubernetesClient.close();
+    mockServer.destroy();
+  }
+
+  @ParameterizedTest(name = "{index}: mcp-server-kubernetes provides the {0} tool")
+  @ValueSource(strings = {
+    "configuration_get",
+    "namespaces_list",
+    "pods_delete",
+    "pods_list",
+    "pods_list_in_namespace",
+    "pods_run"
+  })
+  public void tools(String toolName) {
+    assertThat(client.listTools())
+      .extracting(ToolSpecification::name)
+      .contains(toolName);
+  }
+
+  @Nested
+  class NamespaceOperations {
+
+    @Test
+    void namespaces_list() {
+      kubernetesClient.namespaces()
+        .resource(new NamespaceBuilder().withNewMetadata().withName("a-namespace-to-list").endMetadata().build())
+        .create();
+      assertThat(client.executeTool(ToolExecutionRequest.builder().name("namespaces_list").arguments("{}").build()))
+        .isNotBlank()
+        .satisfies(nsList -> assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(nsList, List.class))
+          .extracting("metadata.name")
+          .contains("a-namespace-to-list"));
+    }
+  }
+
+  @Nested
+  class PodOperations {
+
+    @Test
+    void pods_list() {
+      kubernetesClient.pods()
+        .resource(new PodBuilder().withNewMetadata().withName("a-pod-to-list").endMetadata().build())
+        .create();
+      assertThat(client.executeTool(ToolExecutionRequest.builder().name("pods_list").arguments("{}").build()))
+        .isNotBlank()
+        .satisfies(pList -> assertThat(kubernetesClient.getKubernetesSerialization().unmarshal(pList, List.class))
+          .extracting("metadata.name")
+          .contains("a-pod-to-list"));
+    }
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,19 @@
          <mcp.server.version>999-SNAPSHOT</mcp.server.version>
     -->
         <mcp.server.version>1.0.0.Beta1</mcp.server.version>
+        <langchain4j.version>1.0.0-alpha1</langchain4j.version>
 
     </properties>
 
     <dependencyManagement>
         <dependencies>
+          <dependency>
+            <!-- Used to generate MCP clients in Integration Tests -->
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-mcp</artifactId>
+            <version>${langchain4j.version}</version>
+            <scope>test</scope>
+          </dependency>
           <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Integration tests for the mcp-server-kubernetes running with a MockWebServer.

These tests should be able to run in any OS (as opposed to those based on TestContainers).

These tests rely on langchain4j mcp to create an stdio transport client.

Tests can be run in JVM and native profile.
Passing locally on an x86_64 linux machine.

Closes https://github.com/fabric8io/kubernetes-client/issues/6853