### PR TITLE
add shared to handle sse/stdio and cli parsing/config

### DIFF
--- a/filesystem/pom.xml
+++ b/filesystem/pom.xml
@@ -27,6 +27,10 @@
     </dependencyManagement>
 
     <dependencies>
+       <dependency><groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-shared</artifactId>
+    <version>${version}</version>
+    </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>

--- a/filesystem/src/main/java/io/quarkus/mcp/servers/filesystem/Application.java
+++ b/filesystem/src/main/java/io/quarkus/mcp/servers/filesystem/Application.java
@@ -1,5 +1,6 @@
 package io.quarkus.mcp.servers.filesystem;
 
+import io.quarkus.mcp.servers.shared.SharedApplication;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.annotations.QuarkusMain;
 
@@ -7,20 +8,14 @@ import io.quarkus.runtime.annotations.QuarkusMain;
  * This is the main entry point for the filesystem server.
  * It will start the server and set the fileserver.paths property based on arguments if present.
  */
-@QuarkusMain
-class Application {
+@QuarkusMain(name="filesystem")
+public class Application {
     public static void main(String[] args) {
-        if(args.length > 0) {
-            System.setProperty("fileserver.paths", String.join(",", args));
-        }
-
-        Quarkus.run(null, 
-            (exitCode, exception) -> {
-                if(exception != null) {
-                    exception.printStackTrace();
-                } 
-                System.exit(exitCode);
-                }, 
-                args);
+        SharedApplication.main(args, (remainingArgs) -> {
+            if(remainingArgs.size() > 0) {
+                System.setProperty("fileserver.paths", String.join(",", remainingArgs));
+            }
+            return null;
+        });
     }
 }

--- a/filesystem/src/main/resources/application.properties
+++ b/filesystem/src/main/resources/application.properties
@@ -1,5 +1,2 @@
-quarkus.package.jar.type=uber-jar
-quarkus.package.jar.add-runner-suffix=false
-quarkus.mcp.server.traffic-logging.enabled=true 
-quarkus.mcp.server.traffic-logging.text-limit=50
+quarkus.package.main-class=filesystem
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -27,6 +27,10 @@
     </dependencyManagement>
 
     <dependencies>
+     <dependency><groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-shared</artifactId>
+    <version>${version}</version>
+    </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>

--- a/jdbc/src/main/resources/application.properties
+++ b/jdbc/src/main/resources/application.properties
@@ -1,9 +1,3 @@
-quarkus.package.jar.type=uber-jar
-quarkus.package.jar.add-runner-suffix=false
-#quarkus.log.level=DEBUG
 
 #disable db devservices as we are using direct connection
 %dev.quarkus.datasource.devservices.enabled=false
-
-
-#quarkus.log.console.stderr=true

--- a/jfx/pom.xml
+++ b/jfx/pom.xml
@@ -30,6 +30,10 @@
     </dependencyManagement>
 
     <dependencies>
+     <dependency><groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-shared</artifactId>
+    <version>${version}</version>
+    </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>

--- a/jfx/src/main/resources/application.properties
+++ b/jfx/src/main/resources/application.properties
@@ -1,5 +1,1 @@
-quarkus.package.jar.type=uber-jar
-quarkus.package.jar.add-runner-suffix=false
-#quarkus.log.level=DEBUG
 
-#quarkus.log.console.stderr=true

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -58,3 +58,37 @@ Example for MacOS arm64 (M1, M2, etc.):
 ```
 
 You can of course also rename the executable to something else, like `mcp-server-kubernetes` if you want.
+
+## How to build/test
+
+```bash
+mvn clean install
+```
+
+There are profiles to add right JDBC driver to the build for easy testing.
+
+i.e. `h2`, `postgresql`, `sqlite` etc.
+
+Examples:
+
+h2 on an empty in-memory database:
+
+```bash
+mvn quarkus:dev -Dh2
+```
+
+postgresql with a pre-configured database running in a container:
+
+```bash
+podman run -p 5432:5432 -d sakiladb/postgres:latest
+mvn quarkus:dev -Dpostgresql
+```
+
+sqlite with a pre-configured database running in a container
+using `./test.db` as the database file:
+
+```bash
+mvn quarkus:dev -Dsqlite -Djdbc.url=jdbc:sqlite:./test.db
+```
+
+

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+        <groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-shared</artifactId>
+       <version>${version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
         </dependency>

--- a/kubernetes/src/main/resources/application.properties
+++ b/kubernetes/src/main/resources/application.properties
@@ -1,10 +1,3 @@
-quarkus.package.jar.type=uber-jar
-quarkus.package.jar.add-runner-suffix=false
-
-# Logging
-#quarkus.log.level=DEBUG
-#quarkus.log.console.stderr=true
-
 %test.quarkus.kubernetes-client.devservices.enabled=true
 %test.quarkus.kubernetes-client.devservices.override-kubeconfig=true
 %test.quarkus.kubernetes-client.devservices.flavor=api-only

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>shared</module>
         <module>jdbc</module>
         <module>filesystem</module>
         <module>jfx</module>
@@ -53,9 +54,23 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
           </dependency>
+          
         </dependencies>
     </dependencyManagement>
 
+<!-- TODO: should this be moved to each module instead?-->
+<dependencies>
+          <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-stdio</artifactId>
+            <version>${mcp.server.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-sse</artifactId>
+            <version>${mcp.server.version}</version>
+          </dependency>
+</dependencies>
 
 <build>
     <extensions>

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,5 @@
+# Shared Model Context Protocol Server module
+
+This Model Context Protocol(MCP) server enables Large Language Models (LLMs) to make drawings using JavaFX primities.
+
+This module is to share common code between the different MCP server modules.

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.quarkus.mcp.servers</groupId>
+    <artifactId>mcp-server-shared</artifactId>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp.servers</groupId>
+        <artifactId>mcp-servers-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+
+
+    <build>
+  <plugins>
+    <plugin>
+      <groupId>io.smallrye</groupId>
+      <artifactId>jandex-maven-plugin</artifactId>
+      <version>3.2.3</version>
+      <executions>
+        <execution>
+          <id>make-index</id>
+          <goals>
+            <goal>jandex</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+    
+</project>

--- a/shared/src/main/java/io/quarkus/mcp/servers/shared/McpCliConfigSource.java
+++ b/shared/src/main/java/io/quarkus/mcp/servers/shared/McpCliConfigSource.java
@@ -1,0 +1,83 @@
+package io.quarkus.mcp.servers.shared;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * A shared config source for MCP CLI's
+ * Will treat any argument starting with -- or -D as a key/value pair.
+ * 
+ */
+public class McpCliConfigSource implements ConfigSource {
+
+    static List<String> setupConfigSource(String[] args) {
+        List<String> remainingArgs = new ArrayList<>();
+        for (String arg : args) {
+            if (arg.startsWith("--") || arg.startsWith("-D")) {
+                String[] parts = arg.substring(2).split("=");
+                if (parts.length == 2) {
+                 // System.out.println("Setting " + parts[0] + " to " + parts[1]);
+                  McpCliConfigSource.put(parts[0], parts[1]);
+                } else {
+                  McpCliConfigSource.put(parts[0], "true");
+                }
+
+                if(parts[0].equals("debug")) {
+                  put("quarkus.mcp.server.client-logging.default-level", "DEBUG");
+                  put("quarkus.mcp.server.traffic-logging.enabled", "true");
+                  put("quarkus.log.category.\"io.quarkus.mcp.servers\".level", "DEBUG");
+                }
+            } else {
+                remainingArgs.add(arg);
+            }
+        }
+
+        boolean sse = Boolean.parseBoolean(configuration.get("sse"));
+
+        if(sse) {
+            put("quarkus.http.host-enabled", "true");
+            put("quarkus.mcp.server.stdio.enabled", "false");
+            
+        } else {
+            put("quarkus.http.host-enabled", "false");
+            put("quarkus.mcp.server.stdio.enabled", "true");
+        }
+        
+        return remainingArgs;
+    }
+    
+    private static final Map<String, String> configuration = new HashMap<>();
+
+    static {
+     //   configuration.put("hass-server", "http://homeassistant.local:8123");
+    }
+
+    public static void put(String key, String value) {
+        configuration.put(key, value);
+    }
+
+    @Override
+    public int getOrdinal() {
+        return 275;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return configuration.keySet();
+    }
+
+    @Override
+    public String getValue(final String propertyName) {
+        return configuration.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return McpCliConfigSource.class.getSimpleName();
+    }
+}

--- a/shared/src/main/java/io/quarkus/mcp/servers/shared/SharedApplication.java
+++ b/shared/src/main/java/io/quarkus/mcp/servers/shared/SharedApplication.java
@@ -1,0 +1,28 @@
+package io.quarkus.mcp.servers.shared;
+
+import java.util.List;
+import java.util.function.Function;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class SharedApplication {
+
+    public static void main(String[] args) {
+        main(args, (remainingArgs) -> null);
+    }
+
+    public static void main(String[] args, Function<List<String>, Void> onArgsProcessed) {
+       onArgsProcessed.apply(McpCliConfigSource.setupConfigSource(args));
+
+        Quarkus.run(null, 
+            (exitCode, exception) -> {
+                if(exception != null) {
+                    exception.printStackTrace();
+                } 
+                System.exit(exitCode);
+                }, 
+                args);
+    }
+}

--- a/shared/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/shared/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+io.quarkus.mcp.servers.shared.McpCliConfigSource

--- a/shared/src/main/resources/application.properties
+++ b/shared/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.package.jar.type=uber-jar
+quarkus.package.jar.add-runner-suffix=false
+
+%dev.quarkus.mcp.server.stdio.enabled=false
+%dev.quarkus.http.host-enabled=true


### PR DESCRIPTION
adds shared module to:

1) reduce application.properties duplication
2) unify setup/config
3) allow passing `--sse` to any server and enable sse otherwise turn it off.
4) still allow individual mcp to have its own main, just need to be explicit about it.
5) passing `--debug` now enables mcp debug and traffic logging 