### PR TITLE
Add option to add jdbc.user and jdbc.password from properties file or…

### DIFF
--- a/jdbc/.scripts/mcpjdbc.java
+++ b/jdbc/.scripts/mcpjdbc.java
@@ -40,6 +40,9 @@ class jdbc implements Callable<Integer> {
     @Option(names = { "-p", "--password" }, description = "Password to connect to database")
     String password;
 
+    @Option(names = { "-f", "--file" }, description = "Environment file to load JDBC credentials from")
+    String file;
+
     public static void main(String... args) {
         int exitCode = new CommandLine(new jdbc()).execute(args);
         System.exit(exitCode);
@@ -98,6 +101,10 @@ class jdbc implements Callable<Integer> {
         }
         if (password != null) {
             command.add("-Djdbc.password=" + password);
+        }
+
+        if (file != null) {
+            command.add("-Djdbc.file=" + file);
         }
 
         System.getProperties().forEach((key, value) -> {

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -41,6 +41,17 @@ You can also specify a user and password separately, here for a PostgreSQL datab
 jbang jdbc@quarkiverse/quarkus-mcp-servers jdbc:postgresql://localhost:5432/sakila -u sakila -p p_ssW0rd
 ```
 
+You can also specify a user and password from environment parameers. properties file, here for a PostgreSQL database:
+```shell
+jbang jdbc@quarkiverse/quarkus-mcp-servers jdbc:postgresql://localhost:5432/sakila -f /path/to/properties/file
+```
+
+```properties
+# /path/to/properties/file
+jdbc.user=sakila
+jdbc.password=p_ssW0rd
+```
+
 ## Downloadable databases
 
 JBang can download files from the web and feed them directly to databases like h2 and sqlite.


### PR DESCRIPTION
Add option to add jdbc.user and jdbc.password from properties file or environment instead of plain text on command to bypass some company's policy.