### PR TITLE
Adopt Quarkiverse POM as parent for project configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    <parent>
+        <groupId>io.quarkiverse</groupId>
+        <artifactId>quarkiverse-parent</artifactId>
+        <version>19</version>
+    </parent>
     <groupId>io.quarkiverse.mcp.servers</groupId>
     <artifactId>mcp-servers-parent</artifactId>
     <version>999-SNAPSHOT</version>


### PR DESCRIPTION
- Migrate project to use Quarkiverse parent POM for standardization.
- Update project dependencies and configuration to align with Quarkiverse conventions.
