### PR TITLE
(fix) #64 enable MCPServerJDBC for HTTP listening

### DIFF
--- a/jdbc/src/main/java/io/quarkiverse/mcp/servers/jdbc/MCPServerJDBC.java
+++ b/jdbc/src/main/java/io/quarkiverse/mcp/servers/jdbc/MCPServerJDBC.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -28,6 +29,7 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolCallException;
 
+@ApplicationScoped
 public class MCPServerJDBC {
 
     @Inject


### PR DESCRIPTION
Hi. I had the same problem as https://github.com/quarkiverse/quarkus-mcp-servers/issues/64

The jbang cli would download an early access jar, jar would not listen to HTTP.

I reproduced the problem cloning the https://github.com/quarkiverse/quarkus-mcp-servers and starting the jdbc server, it would boot, but it would not listen on the port.

I believe this was just typo, the bean was not registered. Registering it fixes it, see below where then I successfuly started the jdbc server in idea. See port 8080 and "Listening on".

Tested against 999-SNAPSHOT. I tested the Dev UI and it will correctly show the jdbc Tools on http://localhost:8080/q/dev-ui/io.quarkiverse.mcp.quarkus-mcp-server-sse/tools

![Capture d’écran du 2025-05-19 16-38-17](https://github.com/user-attachments/assets/1c310f33-dfda-4dbe-84b3-0875cf746ba4)
